### PR TITLE
Resolve errors when building with clang :

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,8 @@
 {
-  'targets': [
+    'variables': {
+        'NODE_VERSION%':'<!(node -p \"process.versions.node.split(\\\".\\\")[0]\")'
+    },
+    'targets': [
     {
       'target_name': 'kerberos',
       'include_dirs': [ '<!(node -e "require(\'nan\')")' ],
@@ -44,14 +47,11 @@
           }
         }],
         ['OS=="zos"', {
-          'cflags': [ '-qASCII' ],
-          'cflags_cc': [ '-qASCII' ],
           'include_dirs': [
             '$(KRB5_HOME)/include/',
             '$(KRB5_HOME)/include/gssapi/'
           ],
           'libraries': [
-            '$(KRB5_HOME)/lib/libgssrpc.a',
             '$(KRB5_HOME)/lib/libgssapi_krb5.a',
             '$(KRB5_HOME)/lib/libkrb5.a',
             '$(KRB5_HOME)/lib/libk5crypto.a',
@@ -59,6 +59,10 @@
             '$(KRB5_HOME)/lib/libkrb5support.a'
           ],
           "libraries!": ["-lkrb5", "-lgssapi_krb5"]
+        }],
+        ['NODE_VERSION < 18', {
+            'cflags': [  '-qascii' ],
+            'cflags_cc': [ '-qascii' ]
         }]
       ]
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,45 +3063,6 @@
         "semver": "^5.4.1"
       }
     },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
-      "dev": true,
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "*",
-            "fstream": "^1.0.2",
-            "inherits": "2"
-          }
-        }
-      }
-    },
     "node-ninja": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/node-ninja/-/node-ninja-1.0.2.tgz",
@@ -3563,7 +3524,6 @@
         "minimist": "^1.1.2",
         "mkdirp": "^0.5.1",
         "node-abi": "^2.2.0",
-        "node-gyp": "^3.0.3",
         "node-ninja": "^1.0.1",
         "noop-logger": "^0.1.0",
         "npm-which": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,7 @@
   "version": "1.1.3",
   "description": "Kerberos library for Node.js",
   "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mongodb-js/kerberos.git"
-  },
+  "repository": "ibmruntimes/kerberos",
   "keywords": [
     "kerberos",
     "security",
@@ -14,7 +11,7 @@
   ],
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.14.0",
+    "nan": "^2.17.0",
     "prebuild-install": "^5.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
binding.gyp : Remove -qascii for clang compiler i.e node v18 or above . Removed library libgssrpc as not used in compilation.
package.json: Update repository path and nan package.
package-lock.json : Remove node-gyp tag with v3.8.0 .

