### PR TITLE
Resolve build issues

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -59,7 +59,7 @@
             '$(KRB5_HOME)/lib/libcom_err.a',
             '$(KRB5_HOME)/lib/libkrb5support.a'
           ],
-          "libraries!": ["-lkrb5", "-lgssapi_krb5"]
+          'libraries!': ['-lkrb5', '-lgssapi_krb5']
         }],
         ['NODE_VERSION < 18', {
             'cflags': [  '-qascii' ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  'variables': {
+        'NODE_VERSION%':'<!(node -p \"process.versions.node.split(\\\".\\\")[0]\")'
+  },
   'targets': [
     {
       'target_name': 'kerberos',
@@ -57,6 +60,10 @@
             '$(KRB5_HOME)/lib/libkrb5support.a'
           ],
           "libraries!": ["-lkrb5", "-lgssapi_krb5"]
+        }],
+        ['NODE_VERSION < 18', {
+            'cflags': [  '-qascii' ],
+            'cflags_cc': [ '-qascii' ]
         }]
       ]
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -44,8 +44,6 @@
           }
         }],
         ['OS=="zos"', {
-          'cflags': [ '-qASCII' ],
-          'cflags_cc': [ '-qASCII' ],
           'include_dirs': [
             '$(KRB5_HOME)/include/',
             '$(KRB5_HOME)/include/gssapi/'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bindings": "^1.5.0",
     "nan": "^2.14.0",
     "prebuild-install": "^5.3.0",
-    "node-gyp": "9.3.1"
+    "node-gyp": "^9.3.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.14.0",
-    "prebuild-install": "^5.3.0"
+    "prebuild-install": "^5.3.0",
+    "node-gyp": "9.3.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
- Removes -q compiler flags from binding.gyp
- Add node-gyp as a dependency. Ideally, we node-gyp from prebuild as intended but even the most recent version of prebuild uses node-gyp 6.1.0 which still uses the -q compiler flags. This was fixed in node-gyp 9.3.0 (https://github.com/nodejs/node-gyp/commit/7d0c83d2a95aca743dff972826d0da26203acfc4). prebuild also doesn't support z/OS and it defaults to building with node-gyp.

node-gyp version in prebuild will need to be bumped if we upstream our changes to https://github.com/mongodb-js/kerberos